### PR TITLE
Automatically reset database and start production server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # ignore oTree-app folder
-/otree/
+otree/
+otree_docker/
+.idea/
+venv/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN echo "Building Otree Image"
 # However, unlike ARG, they are also accessible by containers started from the final image. 
 # ENV values can be overridden when starting a container.
 
-
-ENV OTREE_APP_FOLDER=otree
+# cannot call it "otree", because otree won't let us create a project folder called "otree"
+ENV OTREE_APP_FOLDER=otree_docker
 
 
 # these variables all relate to the postgres database
@@ -38,7 +38,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 
 # https://linuxize.com/post/how-to-install-python-3-7-on-ubuntu-18-04/
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common
+    DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common netcat
 
 # deadsnake repository for multiple python versions on the system
 # RUN add-apt-repository ppa:deadsnakes/ppa
@@ -143,8 +143,8 @@ WORKDIR /home
 COPY bashrc bashrc
 RUN mv bashrc ~/.bashrc
 
-
 WORKDIR /home/otree
+
 # --------------------------------------------------- Expose ports and start processes
 # expose ports of otree, postgres and redis (necessary for the latter two?)
 EXPOSE $PORT_OF_OTREE 6379 5432

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ create docker container from image
 docker run -it -d -p 8000:8000 --name otree otree:1.0
 ```
 
-On the first start, the database is rest. On subsequent starts of the same container, the database is not touched.
+On the first start, the database is reset. On subsequent starts of the same container, the database is not touched.
 
 
 ### 5. (Optional) Resetting the database in the docker container

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ git clone https://github.com/Sebaristoteles/otree_in_one_docker.git .
 	- files: you need the typical files as in the folder following the link above
 	- folders: you need the folders "_static" and "_templates" and one of the example-folders with its content
 3. get your oTree-app folder ready
-	a) easy: name your oTree-app folder "otree" (placed in the same folder as the files from this github project)
+	a) easy: name your oTree-app folder "otree_docker" (placed in the same folder as the files from this github project)
 	b) open the Dockerfile and change "ENV OTREE_APP_FOLDER=..." to the name for your otree app folder (e.g. "my_app")
 - in the Dockerfile you can optionally change other ENV variables that all relate to postgres (more notes in Dockerfile)
 - in the Dockerfile you can optionally change the port that the otree prodserver will listen to later
@@ -56,10 +56,10 @@ create docker container from image
 docker run -it -d -p 8000:8000 --name otree otree:1.0
 ```
 
+On the first start, the database is rest. On subsequent starts of the same container, the database is not touched.
 
 
-### 5. start oTree in docker container
-(unfortunately not possible with dockerfile: if you know how, you are welcome to let me know)
+### 5. (Optional) Resetting the database in the docker container
 ```
 # enter the container
 docker exec -it otree /bin/bash
@@ -67,16 +67,8 @@ docker exec -it otree /bin/bash
 # reset database
 otree resetdb
 # -> confirm with y
-
-# start oTree server
-otree prodserver 8000
-
-# the shell now shows all things the oTree server does
-# -> start an new shell to operate further on your server
-# -> you can close the shell with oTree running, the prodserver will still run
 ```
 if you want to change your oTree app within an existing docker container, see further below
-
 
 
 ### 6. Using oTree directly on port
@@ -124,5 +116,5 @@ docker exec -u root -it otree sh -c 'exec rm -r *'
 # assuming you are in the mother-folder of your new oTree-app folder
 docker cp otree otree:/home
 ```
-after that you have to reset the database again and start the prodserver as explained in "start oTree in docker container"
+after that you have to reset the database again and start the prodserver.
 

--- a/bashrc
+++ b/bashrc
@@ -26,5 +26,5 @@
 export DATABASE_URL=postgres://otree_user:mydbpassword@0.0.0.0:5432/django_test
 export REDIS_URL=redis://localhost:6379
 export OTREE_ADMIN_PASSWORD=my_admin_password
-export OTREE_PRODUCTION=1
+#export OTREE_PRODUCTION=1
 export OTREE_AUTH_LEVEL=DEMO

--- a/bashrc
+++ b/bashrc
@@ -26,5 +26,5 @@
 export DATABASE_URL=postgres://otree_user:mydbpassword@0.0.0.0:5432/django_test
 export REDIS_URL=redis://localhost:6379
 export OTREE_ADMIN_PASSWORD=my_admin_password
-#export OTREE_PRODUCTION=1 # uncomment this line to enable production mode
+export OTREE_PRODUCTION=1
 export OTREE_AUTH_LEVEL=DEMO

--- a/start.sh
+++ b/start.sh
@@ -5,8 +5,8 @@ source /root/.bashrc
 # start redis in background
 redis-server &
 
-# start postgres in background
-pg_ctlcluster 11 main start &
+# start postgres
+pg_ctlcluster 11 main start
 
 # wait for postgres to accept connections
 while ! nc -z 127.0.0.1 5432


### PR DESCRIPTION
Hi Sebastian,

Just some quality of life improvements:
I made some changes to the Dockerfile and the start script to automatically reset the database when the container is first started. The database is not reset after subsequent re-starts. 
I also changed the script to wait for postgres to be available and then start the production server.

Cheers
Christian

PS: I will also look into the nginx issue, but that needs more time.